### PR TITLE
05 herokuデプロイエラーを修正した。

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,3 @@
  *= require_tree .
  *= require_self
  */
- @import "../../node_modules/vuetify/dist/vuetify.min.css";
- @import "../../node_modules/material-design-icons-iconfont/dist/material-design-icons.css";
- @import "../../node_modules/@mdi/font/css/materialdesignicons.css";

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/actioncable": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "material-design-icons-iconfont": "^6.1.0",
     "vue": "^2.6.14",
     "vue-loader": "^15.9.8",
     "vue-router": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,6 +4081,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+material-design-icons-iconfont@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/material-design-icons-iconfont/-/material-design-icons-iconfont-6.1.0.tgz#ffad21a71f2000336fd410cbeba36ddbf301f0f2"
+  integrity sha512-wRJtOo1v1ch+gN8PRsj0IGJznk+kQ8mz13ds/nuhLI+Qyf/931ZlRpd92oq0IRPpZIb+bhX8pRjzIVdcPDKmiQ==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
- herokuデプロイ時に下記エラーが生じた。
```
/tmp/build_b8244ad4/app/frontend/@mdi/font/css/materialdesignicons.css doesn't exist
remote:  /tmp/build_b8244ad4/app/frontend/plugins/node_modules doesn't exist or is not a directory
remote: /tmp/build_b8244ad4/app/frontend/node_modules doesn't exist or is not a directory
```
原因を[ 29c9efc ]で解消。