### PR TITLE
[modify] @mdiをdependencyに移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "vue-template-compiler": "^2.6.14",
     "vuetify": "^2.5.9",
     "webpack": "^4.46.0",
-    "webpack-cli": "^3.3.12"
+    "webpack-cli": "^3.3.12",
+    "@mdi/font": "^6.2.95"
   },
   "version": "0.1.0",
   "devDependencies": {
-    "@mdi/font": "^6.2.95",
     "deepmerge": "^4.2.2",
     "sass": "~1.32",
     "sass-loader": "^12.1.0",


### PR DESCRIPTION
### herokuデプロイ時に下記エラーが生じた。
```
/tmp/build_b8244ad4/app/frontend/@mdi/font/css/materialdesignicons.css doesn't exist
remote:  /tmp/build_b8244ad4/app/frontend/plugins/node_modules doesn't exist or is not a directory
remote: /tmp/build_b8244ad4/app/frontend/node_modules doesn't exist or is not a directory
```
下記文献を参考にして、エラーを解消。
[herokuにデプロイした時のエラー - プログラミングの備忘録](https://miiina01220.hatenablog.com/entry/2021/04/14/151133)
原因を[ 29c9efc ]で解消。