### PR TITLE
herokuデプロイエラー webpack削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "vue-template-compiler": "^2.6.14",
     "vuetify": "^2.5.9",
     "vuex": "^3.6.2",
-    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },
   "version": "0.1.0",


### PR DESCRIPTION
Herokuデプロイ時に下記エラーが出現。
```
error Command "webpack" not found.
remote:  !     Precompiling assets failed.
```
[記事](https://www.somethinggood.work/151)を参考に、yarn remove webpackでwebpackを削除