### PR TITLE
[fix] stringの最大バイト数が767を超えないように制限した

### DIFF
--- a/db/migrate/20211013234246_sorcery_core.rb
+++ b/db/migrate/20211013234246_sorcery_core.rb
@@ -1,10 +1,10 @@
 class SorceryCore < ActiveRecord::Migration[6.1]
   def change
-    create_table :users do |t|
-      t.string :nickname
-      t.string :email,            null: false
-      t.string :crypted_password
-      t.string :salt
+    create_table :users , options: 'ROW_FORMAT=DYNAMIC' do |t|
+      t.string :nickname, limit: 191
+      t.string :email, null: false, limit: 191
+      t.string :crypted_password, limit: 191
+      t.string :salt, limit: 191
       t.integer :role, null: false, default: 0
 
       t.timestamps                null: false

--- a/db/migrate/20211026092517_create_alcohols.rb
+++ b/db/migrate/20211026092517_create_alcohols.rb
@@ -1,7 +1,7 @@
 class CreateAlcohols < ActiveRecord::Migration[6.1]
   def change
-    create_table :alcohols do |t|
-      t.string :name
+    create_table :alcohols , options: 'ROW_FORMAT=DYNAMIC' do |t|
+      t.string :name, limit: 191
       t.integer :alcohol_percentage
       t.integer :alcohol_amount
       t.integer :pure_alcohol_intake

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,8 +22,8 @@ ActiveRecord::Schema.define(version: 2021_10_26_092517) do
     t.index ["analyze_id"], name: "index_alcohol_orders_on_analyze_id"
   end
 
-  create_table "alcohols", charset: "utf8mb4", force: :cascade do |t|
-    t.string "name"
+  create_table "alcohols", charset: "utf8mb4", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.string "name", limit: 191
     t.integer "alcohol_percentage"
     t.integer "alcohol_amount"
     t.integer "pure_alcohol_intake"
@@ -42,11 +42,11 @@ ActiveRecord::Schema.define(version: 2021_10_26_092517) do
     t.index ["user_id"], name: "index_analyzes_on_user_id"
   end
 
-  create_table "users", charset: "utf8mb4", force: :cascade do |t|
-    t.string "nickname"
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
+  create_table "users", charset: "utf8mb4", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.string "nickname", limit: 191
+    t.string "email", limit: 191, null: false
+    t.string "crypted_password", limit: 191
+    t.string "salt", limit: 191
     t.integer "role", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 概要
heroku run rails db:resetを実行した際に下記エラーが出たため、このプルリクエストで解消。
```
Configure a supported :charset and ensure innodb_large_prefix is enabled to support indexes on varchar(255) string columns.
Couldn't create 'heroku_ef4beb7a5e2829e' database. Please check your configuration.
```
### 詳細
下記記事を参考にしてmy.confとdatabase.yml、そして対象となるカラムの文字数制限を設けた。

https://blog.mothule.com/ruby/rails/active-record/ruby-rails-activerecord-fix-mysql56-encode-utf8mb4-key-too-length